### PR TITLE
drop_last added to dataloader.py

### DIFF
--- a/model/dataloader.py
+++ b/model/dataloader.py
@@ -7,7 +7,7 @@ def get_dataloader(anime_train, real_train):
     real_train_dataset = AnimeStyleDataset(real_train)
 
     # Create DataLoaders
-    anime_train_loader = DataLoader(anime_train_dataset, batch_size = 8, shuffle = True, num_workers = 0)
-    real_train_loader = DataLoader(real_train_dataset, batch_size = 8, shuffle = True, num_workers = 0)
+    anime_train_loader = DataLoader(anime_train_dataset, batch_size = 8, shuffle = True, num_workers = 0, drop_last = True)
+    real_train_loader = DataLoader(real_train_dataset, batch_size = 8, shuffle = True, num_workers = 0, drop_last = True)
 
     return anime_train_loader, real_train_loader


### PR DESCRIPTION
-> Fixed uneven batch size error at 1010 epoch. 
-> dataloader.py now uses drop_last =True functionality to deal with this.